### PR TITLE
Adjust one encoding rule of letter 'c'

### DIFF
--- a/kph/__init__.py
+++ b/kph/__init__.py
@@ -65,7 +65,7 @@ RULES[re.compile(r".[R].", re.I)]             = "7"
 RULES[re.compile(r".[SZß].", re.I)]           = "8"
 RULES[re.compile(r"[SZ][C].", re.I)]          = "8"
 RULES[re.compile(r"\s[C][^AHKLOQRUX]", re.I)] = "8"
-RULES[re.compile(r"[C][^AHKOQUX]", re.I)]     = "8"
+RULES[re.compile(r".[C][^AHKOQUX]", re.I)]    = "8"
 RULES[re.compile(r".[DT][CSZ]", re.I)]        = "8"
 RULES[re.compile(r"[CKQ][X].", re.I)]         = "8"
 


### PR DESCRIPTION
I'm totally not sure if I missed anything, but found your implementation today while doing some research and tried it out partially. 

I noticed that the string `abcde` should come out `0182`, but the '8' for the 'c' is missing. So only `012` comes out. 

Also an online tool for the koelner phonetic confirmed my thought. 
So I searched for the cause and corrected it. 

Therefore I wanted to point it out with this PR. 
If I missed something, please ignore it. 